### PR TITLE
docs: add Touch ID sudo setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ nix --extra-experimental-features 'nix-command flakes' flake update
 sh init.sh
 ```
 
+
+### Enable Touch ID for `sudo` (macOS)
+
+Run the following commands to create `/etc/pam.d/sudo_local` from the template and enable Touch ID authentication for `sudo`:
+
+```sh
+sudo cp /etc/pam.d/sudo_local.template /etc/pam.d/sudo_local
+sudo sed -i '' 's/^#auth/auth/' /etc/pam.d/sudo_local
+```
+
 ### Raycast setting
 
 1. Launch Raycast and press <kbd>alt</kbd> + <kbd>Space</kbd>, then run with inputting `Import Preferences & Data`.


### PR DESCRIPTION
### Motivation
- Document how to enable Touch ID authentication for `sudo` on macOS so users can easily configure `/etc/pam.d/sudo_local` from the provided template.

### Description
- Add a new section to `README.md` titled "Enable Touch ID for `sudo` (macOS)" that shows the exact commands to create `/etc/pam.d/sudo_local` from the template and uncomment the `auth` line using `sudo cp /etc/pam.d/sudo_local.template /etc/pam.d/sudo_local` and `sudo sed -i '' 's/^#auth/auth/' /etc/pam.d/sudo_local`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3866ab09483228f415b24cb1089e7)