### PR TITLE
Switch unix script from Deno to Node and add input validation

### DIFF
--- a/raycast/scripts/unix.js
+++ b/raycast/scripts/unix.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run
+#!/usr/bin/env node
 
 // Required parameters:
 // @raycast.schemaVersion 1
@@ -13,9 +13,14 @@
 // Documentation:
 // @raycast.description convert unix time to date
 
-const arg = Deno.args[0]
-if (arg === "now") {
+const arg = process.argv[2]
+if (!arg || arg === "now") {
   console.log(Math.trunc(Date.now() / 1000))
 } else {
-  console.log(new Date(Number(arg) * 1000).toISOString())
+  const unix = Number(arg)
+  if (!Number.isFinite(unix)) {
+    console.error("Invalid unix time. Use 'now' or unix seconds (e.g. 1665846691).")
+    process.exit(1)
+  }
+  console.log(new Date(unix * 1000).toISOString())
 }


### PR DESCRIPTION
### Motivation

- Migrate the `unix` helper script to Node so it runs in environments without Deno and matches common runtime expectations. 
- Improve robustness by validating the provided argument and handling empty or `now` inputs clearly.

### Description

- Replace the Deno shebang and `Deno.args[0]` usage with a Node shebang and `process.argv[2]`.
- Treat a missing argument or the string `now` as a request to print the current Unix timestamp via `Math.trunc(Date.now() / 1000)`.
- Validate numeric input with `Number.isFinite`, print an error and `process.exit(1)` for invalid values, and otherwise convert the provided seconds to an ISO date with `new Date(unix * 1000).toISOString()`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43889918483228f00fdfea3472510)