### PR TITLE
docs: add Raycast snippets (JSON) import instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ sh apply.sh
 
 1. Launch Raycast and press <kbd>alt</kbd> + <kbd>Space</kbd>, then run `Import Preferences & Data`.
 1. Select the `~/dotfiles/raycast/Raycast.rayconfig`.
+
+### Raycast snippets (JSON)
+
+Raycast snippets can be managed as JSON text.
+
+1. In Raycast, run `Import Snippets`.
+1. Select the snippets JSON file you prepared.


### PR DESCRIPTION
### Motivation
- Provide users a simple, documented way to manage Raycast snippets as JSON and import them into Raycast.

### Description
- Add a new "Raycast snippets (JSON)" section that instructs users to run `Import Snippets` in Raycast and select their prepared snippets JSON file.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44f6ff3588322a128cbf78e3d81b5)